### PR TITLE
Add onended event

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ module.exports = function(context, parameters) {
 
       choke.gain.setValueAtTime(1, when);
       choke.gain.linearRampToValueAtTime(0, when + 0.0001);
+      choke.gain.cancelScheduledValues(when + 0.001);
     };
 
     return gain;

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = function(context, parameters) {
       osc.stop(when + duration);
       osc.onended = function() {
         gain.disconnect();
+        if (gain.onended) gain.onended();
       }
 
       oscGain.gain.setValueAtTime(0.0001, when);
@@ -81,7 +82,8 @@ module.exports = function(context, parameters) {
 
       choke.gain.setValueAtTime(1, when);
       choke.gain.linearRampToValueAtTime(0, when + 0.0001);
-      choke.gain.cancelScheduledValues(when + 0.001);
+      choke.gain.cancelScheduledValues(when + 0.0001);
+      osc.stop(when + 0.0001); // stops the oscillator to fire the onended event
     };
 
     return gain;


### PR DESCRIPTION
Since the kick is a sound, it would be nice to have a onended callback (like oscillators and audio buffer source nodes). 

This PR add support to that callback. Usage:

``` js
var kick = Kick(ac)
k = kick()
k.onended = function () { console.log('ended!') }
k.start()
```
