### PR TITLE
Allow parameters as instance basis

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ module.exports = function(context, parameters) {
 
       choke.gain.setValueAtTime(1, when);
       choke.gain.linearRampToValueAtTime(0, when + 0.0001);
+      choke.gain.cancelScheduledValues(when + 0.001);
     };
 
     return gain;

--- a/index.js
+++ b/index.js
@@ -1,32 +1,29 @@
 var NoiseBuffer = require('noise-buffer');
 var noiseBuffer = NoiseBuffer(1);
 
-module.exports = function(context, parameters) {
+function param(v) { return typeof v === 'number' ? v : null }
 
-  parameters = parameters || {};
-  parameters.tone = typeof parameters.tone === 'number' ? parameters.tone : 64;
-  parameters.decay = typeof parameters.decay === 'number' ? parameters.decay : 64;
-  parameters.level = typeof parameters.level === 'number' ? parameters.level : 100;
-
+module.exports = function(context, defaults) {
+  defaults = defaults || {};
   var playingNodes = [];
 
-  return function() {
+  return function(params) {
+    params = params || {};
+
+    var gain = context.createGain();
+    gain.decay = param(params.decay) || param(defaults.decay) || 64
+    gain.tone = param(params.tone) || param(defaults.tone) || 64
 
     var osc = context.createOscillator();
     osc.frequency.value = 54;
-    var gain = context.createGain();
     var oscGain = context.createGain();
     osc.connect(oscGain);
-
-    gain.decay = parameters.decay;
-    gain.tone = parameters.tone;
 
     var choke = context.createGain();
     choke.gain.value = 0;
 
     oscGain.connect(choke);
     choke.connect(gain);
-
 
     gain.start = function(when) {
       if (typeof when !== 'number') {

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = function(context, parameters) {
       osc.stop(when + duration);
       osc.onended = function() {
         gain.disconnect();
+        if (gain.onended) gain.onended();
       }
 
       oscGain.gain.setValueAtTime(0.0001, when);
@@ -81,7 +82,8 @@ module.exports = function(context, parameters) {
 
       choke.gain.setValueAtTime(1, when);
       choke.gain.linearRampToValueAtTime(0, when + 0.0001);
-      choke.gain.cancelScheduledValues(when + 0.001);
+      choke.gain.cancelScheduledValues(when + 0.0001);
+      osc.stop(when + 0.0001); // stops the oscillator to fire the onended event
     };
 
     return gain;

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-##Usage
+## Usage
 
 `npm install --save kick-eight`
 
@@ -11,7 +11,7 @@ var context = new AudioContext();
 // Initialize instrument
 var kick = Kick8(context);
 
-// Create clap audio node (one time use only)
+// Create kick audio node (one time use only)
 var kickNode = kick();
 
 // Connect to target node
@@ -19,4 +19,8 @@ kickNode.connect(context.destination);
 
 // Start
 kickNode.start(context.currentTime);
+
+// You can create another kick with different parameters
+// Accepted optional parameters are: decay and tone
+kickNode = kick({ decay: 100, tone: 60 })
 ```


### PR DESCRIPTION
Allow parameters to be specified on instrument level **and** on instance level:

```
var Kick8 = require('.');
var ac = new AudioContext();
var kick = Kick8({ decay: 60 })
var node1 = kick() // => node1.decay === 60
var node2 = kick({ decay: 100}) // => node2.decay === 100
```

This PR also includes:
- Allow parameters on instance level
- Add an example of instance level parameters to readme.md
- The previous onended event support
- The previous fix to the issue #1 
